### PR TITLE
returned the promise from attempting to merge a PR to fix #47

### DIFF
--- a/plugins/keeper/index.js
+++ b/plugins/keeper/index.js
@@ -30,7 +30,7 @@ const mergePR = (prUrl, prNumber, sha) => {
     squash: SQUASH_MERGES
   }
 
-  put(`${prUrl}/merge`, mergeData, { headers })
+  return put(`${prUrl}/merge`, mergeData, { headers })
 }
 
 const validatePR = (statusesUrl, timeout = MINUTE) =>


### PR DESCRIPTION
results in failures landing in the catch block rather than enabling further successful `then` callbacks to continue